### PR TITLE
task: Determine nullable field by considering constraints

### DIFF
--- a/data_resource_api/factories/orm_factory.py
+++ b/data_resource_api/factories/orm_factory.py
@@ -81,7 +81,8 @@ class ORMFactory(object):
         if isinstance(primary_key, str):
             primary_key = [primary_key]
         for field in fields:
-            if 'required' in field.keys() and field['required'] is True:
+            if ('required' in field.keys() and field['required']) or \
+                ('constraints' in field.keys() and 'required' in field['constraints'].keys() and field['constraints']['required']):
                 nullable = False
             else:
                 nullable = True


### PR DESCRIPTION
This PR adds logic to accommodate schemas that use the `constraints` attribute for marking a field as nullable or not.

Why? The frictionless documentation suggests nesting the `required` attribute within the `constraints` field, and the default Goodwill programs schema (from Google fellows/pathways) defines the schema this way.

https://frictionlessdata.io/specs/table-schema/ 