### PR TITLE
Chore/clean orm factory

### DIFF
--- a/data_resource_api/factories/orm_factory.py
+++ b/data_resource_api/factories/orm_factory.py
@@ -65,7 +65,7 @@ class ORMFactory(object):
                 return True, foreign_key_reference
         return False, None
 
-    def create_sqlalchemy_fields(self, descriptor_fields: list(dict), primary_key: str, foreign_keys=[]):
+    def create_sqlalchemy_fields(self, descriptor_fields: list, primary_key: str, foreign_keys=[]):
         """Build SQLAlchemy fields to be added to new table object.
 
         Args:

--- a/data_resource_api/factories/orm_factory.py
+++ b/data_resource_api/factories/orm_factory.py
@@ -79,13 +79,13 @@ class ORMFactory(object):
         """
 
         def is_required(descriptor_field):
-            has_required_and_true = ('required' in descriptor_field.keys() and descriptor_field['required']) 
+            has_required_key_and_true = ('required' in descriptor_field.keys() and descriptor_field['required']) 
             has_required_in_constraints = (
                 'constraints' in descriptor_field.keys() 
                 and 'required' in descriptor_field['constraints'].keys() 
                 and descriptor_field['constraints']['required']
             )
-            return has_required_and_true or has_required_in_constraints
+            return has_required_key_and_true or has_required_in_constraints
 
         sqlalchemy_fields = {}
 


### PR DESCRIPTION
Cleans up the code in one of the functions in orm_factory.py.

- Moves a complex comparison to a named function so that it is easy to read.
- Flattens nested if else
- Rename `field` variable to `descriptor_field` for clarity.

Requesting a code review. Recommending to not merge until tests are in place.