### PR TITLE
Chore/Improve exception handling

### DIFF
--- a/data_resource_api/api/core/versioned_resource.py
+++ b/data_resource_api/api/core/versioned_resource.py
@@ -8,6 +8,7 @@ the API version number in the request header.
 from flask_restful import Resource
 from flask import request
 from data_resource_api.api.v1_0_0 import ResourceHandler as V1_0_0_ResourceHandler
+from data_resource_api.app.exception_handler import MethodNotAllowed
 
 
 class VersionedResourceParent(Resource):
@@ -43,7 +44,7 @@ class VersionedResource(VersionedResourceParent):
     def get(self, id=None):
         if self.api_schema['get']['enabled']:
             if request.path.endswith('/query'):
-                return {'error': 'Method not allowed.'}, 405
+                raise MethodNotAllowed()
             offset = 0
             limit = 20
             try:
@@ -67,7 +68,7 @@ class VersionedResource(VersionedResourceParent):
                 else:
                     return self.get_resource_handler(request.headers).get_one(id, self.data_model, self.data_resource_name, self.table_schema)
         else:
-            return {'error': 'Method not allowed.'}, 405
+            raise MethodNotAllowed()
 
     def post(self):
         if self.api_schema['post']['enabled']:
@@ -82,37 +83,37 @@ class VersionedResource(VersionedResourceParent):
                 else:
                     return self.get_resource_handler(request.headers).insert_one(self.data_model, self.data_resource_name, self.table_schema, request)
         else:
-            return {'error': 'Method not allowed.'}, 405
+            raise MethodNotAllowed()
 
     def put(self, id):
         if self.api_schema['put']['enabled']:
             if request.path.endswith('/query'):
-                return {'error': 'Method not allowed.'}, 405
+                raise MethodNotAllowed()
             if self.api_schema['put']['secured']:
                 return self.get_resource_handler(request.headers).update_one_secure(id, self.data_model, self.data_resource_name, self.table_schema, self.restricted_fields, request, mode='PUT')
             else:
                 return self.get_resource_handler(request.headers).update_one(id, self.data_model, self.data_resource_name, self.table_schema, self.restricted_fields, request, mode='PUT')
         else:
-            return {'error': 'Method not allowed.'}, 405
+            raise MethodNotAllowed()
 
     def patch(self, id):
         if self.api_schema['patch']['enabled']:
             if request.path.endswith('/query'):
-                return {'error': 'Method not allowed.'}, 405
+                raise MethodNotAllowed()
             if self.api_schema['patch']['secured']:
                 return self.get_resource_handler(request.headers).update_one_secure(id, self.data_model, self.data_resource_name, self.table_schema, self.restricted_fields, request, mode='PATCH')
             else:
                 return self.get_resource_handler(request.headers).update_one_secure(id, self.data_model, self.data_resource_name, self.table_schema, self.restricted_fields, request, mode='PATCH')
         else:
-            return {'error': 'Method not allowed.'}, 405
+            raise MethodNotAllowed()
 
     def delete(self, id):
         if self.api_schema['delete']['enabled']:
             if request.path.endswith('/query'):
-                return {'error': 'Method not allowed.'}, 405
+                raise MethodNotAllowed()
             if self.api_schema['delete']['secured']:
                 return {'message': 'delete secure'}
             else:
                 return {'message': 'delete'}
         else:
-            return {'error': 'Method not allowed.'}, 405
+            raise MethodNotAllowed()

--- a/data_resource_api/api/core/versioned_resource.py
+++ b/data_resource_api/api/core/versioned_resource.py
@@ -9,6 +9,7 @@ from flask_restful import Resource
 from flask import request
 from data_resource_api.api.v1_0_0 import ResourceHandler as V1_0_0_ResourceHandler
 
+
 class VersionedResourceParent(Resource):
     __slots__ = ['data_resource_name',
                  'data_model', 'table_schema', 'api_schema', 'restricted_fields']
@@ -19,7 +20,7 @@ class VersionedResourceParent(Resource):
     def get_api_version(self, headers):
         try:
             api_version = headers['X-Api-Version']
-        except Exception:
+        except KeyError:
             api_version = '1.0.0'
         return api_version
 
@@ -32,10 +33,11 @@ class VersionedResourceParent(Resource):
 
 class VersionedResourceMany(VersionedResourceParent):
     def get(self, id=None):
-        ## route should be parent/<id>/child
+        # route should be parent/<id>/child
         paths = request.path.split('/')
         parent, child = paths[1], paths[3]
         return self.get_resource_handler(request.headers).get_many_one(id, parent, child)
+
 
 class VersionedResource(VersionedResourceParent):
     def get(self, id=None):

--- a/data_resource_api/api/v1_0_0/resource_handler.py
+++ b/data_resource_api/api/v1_0_0/resource_handler.py
@@ -12,6 +12,7 @@ from data_resource_api import ConfigurationFactory
 from data_resource_api.db import Session
 from data_resource_api.app.junc_holder import JuncHolder
 from data_resource_api.logging import LogFactory
+from data_resource_api.app.exception_handler import ApiError
 
 
 class ResourceHandler(object):

--- a/data_resource_api/api/v1_0_0/resource_handler.py
+++ b/data_resource_api/api/v1_0_0/resource_handler.py
@@ -12,7 +12,7 @@ from data_resource_api import ConfigurationFactory
 from data_resource_api.db import Session
 from data_resource_api.app.junc_holder import JuncHolder
 from data_resource_api.logging import LogFactory
-from data_resource_api.app.exception_handler import ApiError, ApiErrorLog, InternalServerError
+from data_resource_api.app.exception_handler import ApiError, ApiUnhandledError, InternalServerError
 
 
 class ResourceHandler(object):
@@ -195,7 +195,7 @@ class ResourceHandler(object):
                     errors.append(
                         'Unknown or restricted field \'{}\' found.'.format(field))
             if len(errors) > 0:
-                raise ApiErrorLog('Invalid request body.', 400, errors)
+                raise ApiUnhandledError('Invalid request body.', 400, errors)
             else:
                 try:
                     session = Session()
@@ -210,7 +210,7 @@ class ResourceHandler(object):
                     else:
                         return response, 200
                 except Exception as e:
-                    raise ApiErrorLog('Failed to create new resource.', 400)
+                    raise ApiUnhandledError('Failed to create new resource.', 400)
                 finally:
                     session.close()
         else:
@@ -304,7 +304,7 @@ class ResourceHandler(object):
 
             return {'message': 'Successfully added new resource.', 'id': id_value}, 201
         except Exception as e:
-            raise ApiErrorLog('Failed to create new resource.', 400)
+            raise ApiUnhandledError('Failed to create new resource.', 400)
         finally:
             session.close()
 
@@ -372,7 +372,7 @@ class ResourceHandler(object):
             response = self.build_json_from_object(result)
             return response, 200
         except Exception:
-            raise ApiErrorLog(f"Resource with id '{id}' not found.", 404)
+            raise ApiUnhandledError(f"Resource with id '{id}' not found.", 404)
 
     def get_many_one(self, id: int, parent: str, child: str):
         """Retrieve the many to many relationship data of a parent and child.
@@ -438,9 +438,9 @@ class ResourceHandler(object):
             data_obj = session.query(data_model).filter(
                 getattr(data_model, primary_key) == id).first()
             if data_obj is None:
-                raise ApiErrorLog(f"Resource with id '{id}' not found.", 404)
+                raise ApiUnhandledError(f"Resource with id '{id}' not found.", 404)
         except Exception as e:
-            raise ApiErrorLog(f"Resource with id '{id}' not found.", 404)
+            raise ApiUnhandledError(f"Resource with id '{id}' not found.", 404)
 
         schema = Schema(table_schema)
         errors = []

--- a/data_resource_api/api/v1_0_0/resource_handler.py
+++ b/data_resource_api/api/v1_0_0/resource_handler.py
@@ -12,7 +12,7 @@ from data_resource_api import ConfigurationFactory
 from data_resource_api.db import Session
 from data_resource_api.app.junc_holder import JuncHolder
 from data_resource_api.logging import LogFactory
-from data_resource_api.app.exception_handler import ApiError
+from data_resource_api.app.exception_handler import ApiError, ApiErrorLog, InternalServerError
 
 
 class ResourceHandler(object):
@@ -163,7 +163,8 @@ class ResourceHandler(object):
                     data_resource_name, offset, limit, row_count)
             response['links'] = links
         except Exception:
-            self.logger.exception()
+            raise InternalServerError()
+
         session.close()
         return response, 200
 
@@ -178,7 +179,7 @@ class ResourceHandler(object):
         try:
             request_obj = request_obj.json
         except Exception:
-            return {'error': 'No request body found.'}, 400
+            raise ApiError('No request body found.', 400)
 
         errors = []
         schema = Schema(table_schema)
@@ -194,7 +195,7 @@ class ResourceHandler(object):
                     errors.append(
                         'Unknown or restricted field \'{}\' found.'.format(field))
             if len(errors) > 0:
-                return {'message': 'Invalid request body.', 'errors': errors}, 400
+                raise ApiErrorLog('Invalid request body.', 400, errors)
             else:
                 try:
                     session = Session()
@@ -209,11 +210,11 @@ class ResourceHandler(object):
                     else:
                         return response, 200
                 except Exception as e:
-                    return {'error': 'Failed to create new resource.'}, 400
+                    raise ApiErrorLog('Failed to create new resource.', 400)
                 finally:
                     session.close()
         else:
-            return {'error': 'Data schema validation error.'}, 400
+            raise SchemaValidationFailure()
 
         return {'message': 'querying data resource'}, 200
 
@@ -248,14 +249,14 @@ class ResourceHandler(object):
         try:
             request_obj = request_obj.json
         except Exception:
-            return {'error': 'No request body found.'}, 400
+            raise ApiError('No request body found.', 400)
 
         schema = Schema(table_schema)
         errors = []
         accepted_fields = []
 
         if not validate(table_schema):
-            return {'error': 'Data schema validation error.'}, 400
+            raise SchemaValidationFailure()
 
         # Check for required fields
         for field in table_schema['fields']:
@@ -264,7 +265,7 @@ class ResourceHandler(object):
             if field['required']:
                 if not field['name'] in request_obj.keys():
                     errors.append(
-                        'Required field \'{}\' is missing'.format(field['name'])
+                        f"Required field '{field['name']}' is missing."
                     )
 
         valid_fields = []
@@ -282,33 +283,30 @@ class ResourceHandler(object):
                         values = [values]
                     many_query.append([field, values, junc_table])
                 else:
-                    errors.append(f"Unknown field '{field}' found")
+                    errors.append(f"Unknown field '{field}' found.")
 
         if len(errors) > 0:
-            return {'message': 'Invalid request body.', 'errors': errors}, 400
-        else:
-            try:
-                session = Session()
-                new_object = data_model()
-                for field in valid_fields:
-                    value = request_obj[field]
-                    setattr(new_object, field, value)
-                session.add(new_object)
-                session.commit()
-                id_value = getattr(new_object, table_schema['primaryKey'])
+            raise ApiError('Invalid request body.', 400, errors)
 
-                # process the many_query
-                for field, values, table in many_query:
-                    try:
-                        self.process_many_query(session, table, id_value, field, data_resource_name, values)
-                    except Exception as e:
-                        return {'error': 'Failed to handle many to many relationship.'}, 400
+        try:
+            session = Session()
+            new_object = data_model()
+            for field in valid_fields:
+                value = request_obj[field]
+                setattr(new_object, field, value)
+            session.add(new_object)
+            session.commit()
+            id_value = getattr(new_object, table_schema['primaryKey'])
 
-                return {'message': 'Successfully added new resource.', 'id': id_value}, 201
-            except Exception as e:
-                return {'error': 'Failed to create new resource.'}, 400
-            finally:
-                session.close()
+            # process the many_query
+            for field, values, table in many_query:
+                self.process_many_query(session, table, id_value, field, data_resource_name, values)
+
+            return {'message': 'Successfully added new resource.', 'id': id_value}, 201
+        except Exception as e:
+            raise ApiErrorLog('Failed to create new resource.', 400)
+        finally:
+            session.close()
 
     def process_many_query(self, session: object, table, id_value: int, field: str, data_resource_name: str, values: list):
         """Iterates over values and adds the items to the junction table
@@ -323,15 +321,19 @@ class ResourceHandler(object):
         parent_column = f'{data_resource_name}_id'
         relationship_column = f'{field}_id'
 
-        for value in values:
-            cols = {
-                f'{parent_column}': id_value,
-                f'{relationship_column}': value
-            }
+        try:
+            for value in values:
+                cols = {
+                    f'{parent_column}': id_value,
+                    f'{relationship_column}': value
+                }
 
-            insert = table.insert().values(**cols)
-            session.execute(insert)
-            session.commit()
+                insert = table.insert().values(**cols)
+                session.execute(insert)
+                session.commit()
+
+        except Exception as e:
+            raise InternalServerError()
 
     @token_required(ConfigurationFactory.get_config().get_oauth2_provider())
     def get_one_secure(self, id, data_model, data_resource_name, table_schema):
@@ -370,7 +372,7 @@ class ResourceHandler(object):
             response = self.build_json_from_object(result)
             return response, 200
         except Exception:
-            return {'error': 'Resource with id \'{}\' not found.'.format(id)}, 404
+            raise ApiErrorLog(f"Resource with id '{id}' not found.", 404)
 
     def get_many_one(self, id: int, parent: str, child: str):
         """Retrieve the many to many relationship data of a parent and child.
@@ -380,18 +382,19 @@ class ResourceHandler(object):
             parent (str): Type of parent
             child (str): Type of child
         """
-
         join_table = JuncHolder.lookup_table(parent, child)
 
         # This should not be reachable
         # if join_table is None:
         #     return {'error': f"relationship '{child}' of '{parent}' not found."}
+        try:
+            session = Session()
+            cols = {f'{parent}_id': id}
+            query = session.query(join_table).filter_by(**cols).all()
 
-        session = Session()
-        cols = {f'{parent}_id': id}
-        query = session.query(join_table).filter_by(**cols).all()
-
-        children = [value[1] for value in query]
+            children = [value[1] for value in query]
+        except Exception:
+            raise InternalServerError()
 
         return {f'{child}': children}, 200
 
@@ -427,7 +430,7 @@ class ResourceHandler(object):
         try:
             request_obj = request_obj.json
         except Exception:
-            return {'error': 'No request body found.'}, 400
+            raise ApiError('No request body found.', 400)
 
         try:
             primary_key = table_schema['primaryKey']
@@ -435,9 +438,9 @@ class ResourceHandler(object):
             data_obj = session.query(data_model).filter(
                 getattr(data_model, primary_key) == id).first()
             if data_obj is None:
-                return {'error': 'Resource with id \'{}\' not found.'.format(id)}, 404
+                raise ApiErrorLog(f"Resource with id '{id}' not found.", 404)
         except Exception as e:
-            return {'error': 'Resource with id \'{}\' not found.'.format(id)}, 404
+            raise ApiErrorLog(f"Resource with id '{id}' not found.", 404)
 
         schema = Schema(table_schema)
         errors = []
@@ -447,30 +450,32 @@ class ResourceHandler(object):
                 accepted_fields.append(field['name'])
             for field in request_obj.keys():
                 if field not in accepted_fields:
-                    errors.append('Unknown field \'{}\' found'.format(field))
+                    errors.append(f"Unknown field '{field}' found.")
                 elif field in restricted_fields:
                     errors.append(
-                        'Cannot update restricted field \'{}\''.format(field))
+                        f"Cannot update restricted field '{field}'.")
         else:
-            return {'error': 'Data schema validation error.'}, 400
+            raise ApiError('Data schema validation error.', 400)
 
         if len(errors) > 0:
-            return {'message': 'Invalid request body.', 'errors': errors}, 400
-        else:
-            if mode == 'PATCH':
-                for key, value in request_obj.items():
-                    setattr(data_obj, key, value)
-                session.commit()
-            elif mode == 'PUT':
-                for field in table_schema['fields']:
-                    if field['required'] and field['name'] not in request_obj.keys():
-                        errors.append('Required field \'{}\' is missing'.format(field['name']))
-                if len(errors) > 0:
-                    return {'message': 'Invalid request body.', 'errors': errors}, 400
-                for key, value in request_obj.items():
-                    setattr(data_obj, key, value)
-                session.commit()
-            return {'message': 'Successfully updated resource \'{}\''.format(id)}, 201
+            raise ApiError('Invalid request body.', 400, errors)
+
+        if mode == 'PATCH':
+            for key, value in request_obj.items():
+                setattr(data_obj, key, value)
+            session.commit()
+        elif mode == 'PUT':
+            for field in table_schema['fields']:
+                if field['required'] and field['name'] not in request_obj.keys():
+                    errors.append(f"Required field '{field['name']}' is missing.")
+
+            if len(errors) > 0:
+                raise ApiError('Invalid request body.', 400, errors)
+
+            for key, value in request_obj.items():
+                setattr(data_obj, key, value)
+            session.commit()
+        return {'message': f"Successfully updated resource '{id}'."}, 201
 
     @token_required(ConfigurationFactory.get_config().get_oauth2_provider())
     def delete_one_secure(self, id, data_resource):

--- a/data_resource_api/api/v1_0_0/resource_handler.py
+++ b/data_resource_api/api/v1_0_0/resource_handler.py
@@ -332,7 +332,7 @@ class ResourceHandler(object):
                 session.execute(insert)
                 session.commit()
 
-        except Exception as e:
+        except Exception:
             raise InternalServerError()
 
     @token_required(ConfigurationFactory.get_config().get_oauth2_provider())

--- a/data_resource_api/app/data_model_manager.py
+++ b/data_resource_api/app/data_model_manager.py
@@ -83,7 +83,7 @@ class DataModelManagerSync(object):
                     self.logger.info(
                         'Waiting on database to become available.... {}/{}'.format(retries, max_retries))
                 else:
-                    self.logger.exception()
+                    self.logger.exception(f'Error occured upgrading database.')
 
             retries += 1
             sleep(retry_wait)

--- a/data_resource_api/app/data_model_manager.py
+++ b/data_resource_api/app/data_model_manager.py
@@ -83,11 +83,11 @@ class DataModelManagerSync(object):
                     self.logger.info(
                         'Waiting on database to become available.... {}/{}'.format(retries, max_retries))
                 else:
-                    self.logger.exception(f'Error {e}')
-                    
+                    self.logger.exception()
+
             retries += 1
             sleep(retry_wait)
-        
+
         self.logger.info('Upgrade loop exited')
 
     def get_sleep_interval(self):
@@ -187,7 +187,7 @@ class DataModelManagerSync(object):
             session.add(checksum)
             session.commit()
         except Exception as e:
-            self.logger.exception('Error adding checksum {}'.format(e))
+            self.logger.exception('Error adding checksum')
         session.close()
 
     def update_model_checksum(self, table_name: str, model_checksum: str):
@@ -210,7 +210,7 @@ class DataModelManagerSync(object):
             session.commit()
             updated = True
         except Exception as e:
-            self.logger.exception('Error updating checksum {}'.format(e))
+            self.logger.exception('Error updating checksum')
         session.close()
         return updated
 
@@ -230,7 +230,7 @@ class DataModelManagerSync(object):
             checksum = session.query(Checksum).filter(
                 Checksum.data_resource == table_name).first()
         except Exception as e:
-            self.logger.exception('Error retrieving checksum {}'.format(e))
+            self.logger.exception('Error retrieving checksum')
         session.close()
         return checksum
 
@@ -290,37 +290,35 @@ class DataModelManagerSync(object):
         """
         self.logger.info('Checking data models')
         schema_dir = self.get_data_resource_schema_path()
-        
+
         if not os.path.exists(schema_dir) or not os.path.isdir(schema_dir):
             self.logger.exception(
-                'Unable to locate schema directory {}'.format(schema_dir))
+                f"Unable to locate schema directory '{schema_dir}'")
 
         schemas = os.listdir(schema_dir)
         for schema in schemas:
             if os.path.isdir(os.path.join(schema_dir, schema)):
                 self.logger.exception(
-                    'Cannot open a nested schema directory {}'.format(schema))
+                    f"Cannot open a nested schema directory '{schema}'")
                 return
 
             try:
                 with open(os.path.join(schema_dir, schema), 'r') as fh:
                     schema_dict = json.load(fh)
-                
+
                 schema_filename = schema
             except Exception as e:
                 self.logger.exception(
-                    'Error loading json from schema file {} {}'.format(schema, e))
-            
+                    f"Error loading json from schema file '{schema}'")
+
             self.work_on_schema(schema_dict, schema_filename)
 
-            
         self.logger.info('Completed check of data models')
-
 
     def work_on_schema(self, schema_dict: dict, schema_filename: str):
         """Operate on a schema dict for data model changes.
 
-        Note: 
+        Note:
             This method is the core worker for this class. It has the responsibility of
             monitoring all data resource models and determining if they have changed. If
             changes are detected, it also has the responsibility of building and applying
@@ -372,7 +370,7 @@ class DataModelManagerSync(object):
 
         except Exception as e:
             self.logger.exception(
-                f'Error loading data resource schema {schema_filename} {e}')
+                f"Error loading data resource schema '{schema_filename}'")
 
 
 class DataModelManager(Thread, DataModelManagerSync):
@@ -382,4 +380,3 @@ class DataModelManager(Thread, DataModelManagerSync):
 
     def run(self):
         DataModelManagerSync.run(self)
-

--- a/data_resource_api/app/data_resource_manager.py
+++ b/data_resource_api/app/data_resource_manager.py
@@ -4,14 +4,12 @@ The Data Resource Manager manages the lifecycles of all data resources. It is re
 creating the Flask application that sits at the front of the data resource.
 
 """
-
 import os
 import json
 import hashlib
 from threading import Thread
 from time import sleep
 from flask import Flask
-from brighthive_authlib import OAuth2ProviderError
 from flask_restful import Api, Resource
 from data_resource_api.factories import ORMFactory, DataResourceFactory
 from data_resource_api.config import ConfigurationFactory

--- a/data_resource_api/app/exception_handler.py
+++ b/data_resource_api/app/exception_handler.py
@@ -1,0 +1,51 @@
+import json
+from brighthive_authlib import OAuth2ProviderError
+from data_resource_api.logging import LogFactory
+from werkzeug.exceptions import NotFound
+
+
+class ApiError(Exception):
+    def __init__(self, message, status_code=400, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        self.status_code = status_code
+        self.payload = payload or ()
+
+    def get_message(self):
+        logger = LogFactory.get_console_logger('data-resource-manager')
+        logger.exception()
+        resp = dict(self.payload)
+        resp['message'] = self.message
+        return jsonify(resp)
+
+    def get_status_code(self):
+        return self.status_code
+
+
+def handle_errors(e):
+    """Flask App Error Handler
+
+    A generic error handler for Flask applications.
+
+    Note:
+        This error handler is essentially to ensure that OAuth 2.0 authorization errors
+        are handled in an appropriate fashion. The application configuration used when
+        building the application must set the PROPOGATE_EXPECTIONS environment variable to
+        True in order for the exception to be propogated.
+
+    Return:
+        dict, int: The error message and associated error code.
+
+    """
+    logger = LogFactory.get_console_logger('data-model-manager')
+    logger.exception("Encountered an error while processing a request:")
+    if isinstance(e, OAuth2ProviderError):
+        return json.dumps({'message': 'Access Denied'}), 401
+
+    if isinstance(e, NotFound):
+        return json.dumps({'error': 'Location not found'}), 404
+
+    if isinstance(e, ApiError):
+        return e.get_message(), e.get_status_code()
+
+    return e.get_response()

--- a/data_resource_api/app/exception_handler.py
+++ b/data_resource_api/app/exception_handler.py
@@ -45,7 +45,7 @@ class MethodNotAllowed(ApiError):
 
 
 class InternalServerError(ApiErrorLog):
-    def __init__(self, status_code=400):
+    def __init__(self, status_code=500):
         message = "Internal Server Error"
         ApiError.__init__(self, message, status_code)
 

--- a/data_resource_api/app/exception_handler.py
+++ b/data_resource_api/app/exception_handler.py
@@ -16,7 +16,7 @@ class DRApiError(Exception):
         resp = {}
         resp['error'] = self.message
 
-        if len(self.errors) != 0:
+        if self.errors:
             resp['errors'] = self.errors
 
         return jsonify(resp)
@@ -31,7 +31,7 @@ class ApiError(DRApiError):
     pass
 
 
-class ApiErrorLog(DRApiError):
+class ApiUnhandledError(DRApiError):
     """Returns an error message to client and logs the exception.
     """
     pass
@@ -44,7 +44,7 @@ class MethodNotAllowed(ApiError):
         ApiError.__init__(self, message, status_code)
 
 
-class InternalServerError(ApiErrorLog):
+class InternalServerError(ApiUnhandledError):
     def __init__(self, status_code=500):
         message = "Internal Server Error"
         ApiError.__init__(self, message, status_code)
@@ -86,7 +86,7 @@ def handle_errors(e):
     logger = LogFactory.get_console_logger('data-model-manager')
     logger.exception("Encountered an error while processing a request.")
 
-    if isinstance(e, ApiErrorLog):
+    if isinstance(e, ApiUnhandledError):
         return e.get_message(), e.get_status_code()
 
     return e.get_response()

--- a/data_resource_api/factories/data_resource_factory.py
+++ b/data_resource_api/factories/data_resource_factory.py
@@ -38,12 +38,12 @@ class DataResourceFactory(object):
                      f'/{endpoint_name}/<int:id>',
                      f'/{endpoint_name}/query']
 
-        flask_restful_resource = type(endpoint_name, (VersionedResource,),
-                       {'data_resource_name': table_name,
-                        'data_model': table_obj,
-                        'table_schema': table_schema,
-                        'api_schema': api_schema,
-                        'restricted_fields': restricted_fields})
+        flask_restful_resource = type(endpoint_name, (VersionedResource,), {
+            'data_resource_name': table_name,
+            'data_model': table_obj,
+            'table_schema': table_schema,
+            'api_schema': api_schema,
+            'restricted_fields': restricted_fields})
 
         for idx, resource in enumerate(resources):
             api.add_resource(
@@ -52,7 +52,6 @@ class DataResourceFactory(object):
                 endpoint=f'{endpoint_name}_ep_{idx}'
             )
 
-        
         many_resources = []
 
         if 'custom' in api_schema:
@@ -63,12 +62,12 @@ class DataResourceFactory(object):
                 # ) # DELETE route
                 many_resources.append(f'/{custom_table[1]}/<int:id>/{custom_table[2]}')
 
-        flask_restful_many_resource = type(f'{endpoint_name}Many', (VersionedResourceMany,),
-                       {'data_resource_name': table_name,
-                        'data_model': table_obj,
-                        'table_schema': table_schema,
-                        'api_schema': api_schema,
-                        'restricted_fields': restricted_fields})
+        flask_restful_many_resource = type(f'{endpoint_name}Many', (VersionedResourceMany,), {
+            'data_resource_name': table_name,
+            'data_model': table_obj,
+            'table_schema': table_schema,
+            'api_schema': api_schema,
+            'restricted_fields': restricted_fields})
 
         for idx, resource in enumerate(many_resources):
             print(resource)

--- a/schema/programs.json
+++ b/schema/programs.json
@@ -4,7 +4,7 @@
     "methods": [
       {
         "get": {
-          "enabled": true,
+          "enabled": false,
           "secured": false,
           "grants": ["get:users"]
         },

--- a/schema/programs.json
+++ b/schema/programs.json
@@ -4,7 +4,7 @@
     "methods": [
       {
         "get": {
-          "enabled": false,
+          "enabled": true,
           "secured": false,
           "grants": ["get:users"]
         },

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -98,7 +98,8 @@ frameworks_descriptor = {
       }
     }
   }
-skills_descriptor=  {
+
+skills_descriptor = {
     "api": {
       "resource": "skills",
       "methods": [

--- a/tests/test_custom_descriptor.py
+++ b/tests/test_custom_descriptor.py
@@ -65,9 +65,9 @@ class TestStartup(object):
             response = frameworks_skills_client.get(route)
             body = json.loads(response.data)
 
-            expect(response.status_code).to(equal(200))  # should be 404
+            expect(response.status_code).to(equal(404))
 
-            error_message = "exception is 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."
+            error_message = "Location not found"
             expect(body['error']).to(equal(error_message))
 
         def get_nonexistant_relationship(framework_id: int):


### PR DESCRIPTION
## Overview

This PR uses a new exception pattern. Raise exceptions that implement a certain interface and they will either be logged or not logged and then returned to the client with the appropriate error message.

Previously `except Exception as e:` were abundant and those exceptions were not logged. This change logs those exceptions. This made development difficult as you were unable to see what exceptions were occurring.

The new exception pattern allows us to do a few things,
- return errors to clients from within subroutines
- log exceptions that are important
- consolidate error response code so refactoring in the future is easier

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

### Notes

[I would like ApiError to implement the `get_response()` "interface" correctly.](https://werkzeug.palletsprojects.com/en/0.15.x/exceptions/) Ideally this would allow us to return Werkzeug errors automatically but I think they all have HTML in their error messages. So instead we might need a large switch block and manually return messages based on [Werkzeug error type](https://werkzeug.palletsprojects.com/en/0.15.x/exceptions/).

Some of the exceptions we want to log and some we don't. The current code could handle this better but right now it's not clear what the most useful pattern would be. So currently, [here](https://github.com/brighthive/data-resource-api/blob/chore/improve-exception-handling/data_resource_api/app/exception_handler.py#L62-L92), I am just logging any errors that aren't handled before the logger logs them in the handle_errors function.

## Instructions

 * Review the PR and provide perspective on the pattern used.

Handles #XXX
