### PR TITLE
fix: Correctly handle pagination.

### DIFF
--- a/data_resource_api/api/v1_0_0/resource_handler.py
+++ b/data_resource_api/api/v1_0_0/resource_handler.py
@@ -25,7 +25,7 @@ class ResourceHandler(object):
         ) if not key.startswith('_') and not callable(key) and key not in restricted_fields}
         return resp
 
-    def compute_offset(self, page, items_per_page):
+    def compute_offset(self, page: int, items_per_page: int) -> int:
         """Compute the offset value for pagination.
         Args:
             page (int): The current page to compute the offset from.
@@ -33,9 +33,9 @@ class ResourceHandler(object):
         Returns:
             int: The offset value.
         """
-        return (page - 1) * items_per_page
+        return int(int(int(page) - 1) * int(items_per_page))
 
-    def compute_page(self, offset, items_per_page):
+    def compute_page(self, offset: int, items_per_page: int) -> int:
         """Compute the current page number based on offset.
         Args:
             offset (int): The offset to use to compute the page.
@@ -44,7 +44,7 @@ class ResourceHandler(object):
             int: The page number.
         """
 
-        return int(math.ceil((int(offset) / int(items_per_page)))) + 1
+        return int(math.ceil(((int(offset) + 1) / int(items_per_page))))
 
     def build_links(self, endpoint: str, offset: int, limit: int, rows: int):
         """Build links for a paginated response
@@ -57,6 +57,9 @@ class ResourceHandler(object):
         Returns:
             dict: The links based on the offset and limit
         """
+        offset = int(offset)
+        limit = int(limit)
+        rows = int(rows)
 
         # URL and pages
         url_link = '/{}?offset={}&limit={}'

--- a/tests/resource_handler/test_compute_offset.py
+++ b/tests/resource_handler/test_compute_offset.py
@@ -1,0 +1,44 @@
+from data_resource_api.api.v1_0_0 import ResourceHandler
+from expects import expect, be_an, raise_error, have_property, equal, be_empty, be
+import json
+
+
+class TestComputeOffset(object):
+    def test_compute_offset(self):
+        handler = ResourceHandler()
+
+        expect(handler.compute_offset(1, 20)).to(equal(0))
+        # expect(handler.compute_offset(53, 19)).to(equal(0))
+        # expect(handler.compute_offset(0, 20)).to(equal(0))
+
+    # def test_build_links(self):
+    #     handler = ResourceHandler()
+
+    #     items = [
+    #         handler.build_links('test', 0, 20, 5),
+    #         handler.build_links('test', 1, 20, 55),
+    #         handler.build_links('test', 1, -20, 55)
+    #     ]
+
+    #     for item in items:
+    #         print(json.dumps(item, indent=4))
+
+    def test_compute_page(self):
+        handler = ResourceHandler()
+
+        items = [
+            handler.compute_page(0, 20),
+            handler.compute_page(1, 20),
+            handler.compute_page(20, 20),
+            handler.compute_page(21, 20),
+            handler.compute_page(25, 20)
+        ]
+
+        for item in items:
+            print(item)
+
+        expect(handler.compute_page(0, 20)).to(equal(1))
+        expect(handler.compute_page(1, 20)).to(equal(1))
+        expect(handler.compute_page(19, 20)).to(equal(1))
+        expect(handler.compute_page(20, 20)).to(equal(2))
+        expect(handler.compute_page(99, 20)).to(equal(5))

--- a/tests/test_default_descriptor.py
+++ b/tests/test_default_descriptor.py
@@ -89,3 +89,54 @@ class TestStartup(object):
 
         expect(response.status_code).to(equal(200))
         # expect(body['message']).to(equal('Access Denied'))
+
+    def test_pagination(self, regular_client):
+        def post_a_credential():
+            post_body = {
+                "credential_name": "testtesttest"
+            }
+            response = regular_client.post('/credentials', json=post_body)
+
+            expect(response.status_code).to(equal(201))
+
+            body = json.loads(response.data)
+            return body
+
+        body = post_a_credential()
+        print(json.dumps(body, indent=4))
+
+        # do regular get
+        route = '/credentials'
+        response = regular_client.get(route)
+        body = json.loads(response.data)
+        print(json.dumps(body, indent=4))
+
+        expect(response.status_code).to(equal(200))
+        expect(len(body['credentials'])).not_to(equal(0))
+
+        # do get with pagination
+        route = '/credentials?offset=0&limit=20'
+        response = regular_client.get(route)
+        body = json.loads(response.data)
+        print(json.dumps(body, indent=4))
+
+        expect(response.status_code).to(equal(200))
+
+        # add items till we need the pagination
+        for _ in range(100):
+            body = post_a_credential()
+            print(json.dumps(body, indent=4))
+
+        # do get with pagination
+        route = '/credentials?offset=0&limit=20'
+        response = regular_client.get(route)
+        body = json.loads(response.data)
+        print(json.dumps(body, indent=4))
+        expect(len(body['credentials'])).to(equal(20))
+
+        # do get with pagination
+        route = '/credentials?offset=20&limit=20'
+        response = regular_client.get(route)
+        body = json.loads(response.data)
+        print(json.dumps(body, indent=4))
+        # expect(len(body['credentials'])).to(equal(20))


### PR DESCRIPTION
## Overview

This fixes a pagination bug. Previously the link results on a `GET` would return empty and incorrect numbers. This fix allows the link results to return the correct data.

### Checklist

- [ ] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

 * Start after checking out this branch
 * Start the Data Resource and add a few hundred items.
 * Perform a get and navigate through the links.
 * The links should be correct and the gets should not error.

Handles https://github.com/brighthive/data-resource-api/issues/1
