### PR TITLE
fix: Do not halt when reaching a folder

### DIFF
--- a/data_resource_api/app/data_model_manager.py
+++ b/data_resource_api/app/data_model_manager.py
@@ -300,7 +300,7 @@ class DataModelManagerSync(object):
             if os.path.isdir(os.path.join(schema_dir, schema)):
                 self.logger.exception(
                     f"Cannot open a nested schema directory '{schema}'")
-                return
+                continue
 
             try:
                 with open(os.path.join(schema_dir, schema), 'r') as fh:

--- a/data_resource_api/app/data_resource_manager.py
+++ b/data_resource_api/app/data_resource_manager.py
@@ -222,7 +222,7 @@ class DataResourceManagerSync(object):
             schema_file = os.path.join(schema_dir, schema)
 
             if not os.path.isfile(schema_file):
-                return
+                continue
 
             with open(os.path.join(schema_dir, schema), 'r') as fh:
                 schema_dict = json.load(fh)


### PR DESCRIPTION
## Overview

This is a bug fix. Previously if you included a folder in the descriptor folder the application would `return` from inside of a for loop when it should `continue`.

### Checklist

- [x] PR has a descriptive enough title to be useful in changelogs

## Testing Instructions

### Verify the bug exists
 * checkout version 1.0.2
 * Add a folder to the descriptor folder
 * Start the application per the README
 * It should fail

### Verify the bug fix works
 * Checkout this branch
 * Add a folder to the descriptor folder
 * Start the application per the README
 * The application should start after a minute and accept queries from POSTMAN.

Handles #38 
