### PR TITLE
Check if flask app exists on thread run.

### DIFF
--- a/data_resource_api/app/data_resource_manager.py
+++ b/data_resource_api/app/data_resource_manager.py
@@ -208,6 +208,10 @@ class DataResourceManagerSync(object):
     def monitor_data_resources(self):
         """Monitor all data resources.
         """
+        if self.api is None or self.app is None:
+            self.logger.info("Flask and API have not been initalized yet.")
+            return
+
         self.logger.info('Checking data resources...')
 
         # Get a configured schema dir


### PR DESCRIPTION
Addresses https://github.com/brighthive/data-resource-api/issues/47

On Data Resource Manager startup a thread will attempt to run even if the flask application has not yet been created. This adds a check for this condition and explicitly describes what is occurring instead of printing errors.