### PR TITLE
Fix drop table bug

### DIFF
--- a/data_resource_api/app/data_model_manager.py
+++ b/data_resource_api/app/data_model_manager.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import ProgrammingError
 from data_resource_api.factories import ORMFactory
 from data_resource_api import ConfigurationFactory
 from data_resource_api.factories.table_schema_types import TABLESCHEMA_TO_SQLALCHEMY_TYPES
-from data_resource_api.db import Session, Log, Checksum
+from data_resource_api.db import Base, Session, Log, Checksum
 from data_resource_api.logging import LogFactory
 
 
@@ -53,7 +53,8 @@ class DataModelManagerSync(object):
         self.logger = LogFactory.get_console_logger('data-model-manager')
 
     def run(self):
-        self.run_upgrade()
+        self.initalize_base_models()
+        self.restore_models_from_database()
 
         while True:
             self.logger.info('Data Model Manager Running...')
@@ -62,16 +63,27 @@ class DataModelManagerSync(object):
                 self.get_sleep_interval()))
             sleep(self.get_sleep_interval())
 
-    def run_upgrade(self):
+    def initalize_base_models(self):
+        self.logger.info("Initalizing base models...")
+
         db_active = False
         max_retries = 10
-        retry_wait = 1
         retries = 0
+
+        # needs unit tests
+        def sleep_exponential_backoff(wait_time, exponential_rate):
+            def wait_func():
+                nonlocal wait_time
+                wait_time *= exponential_rate
+                sleep(wait_time)
+            return wait_func
+
+        exponential_sleep = sleep_exponential_backoff(1, 1.5)
+
         while not db_active and retries <= max_retries:
             if retries != 0:
-                retry_wait *= 1.5
                 self.logger.info(f'Sleeping for {retry_wait} seconds...')
-                sleep(retry_wait)
+                exponential_sleep()
 
             retries += 1
 
@@ -99,7 +111,21 @@ class DataModelManagerSync(object):
                 else:
                     self.logger.exception(f'Error occured upgrading database.')
 
-        self.logger.info('Upgrade loop exited')
+        self.logger.info('Base models initalized.')
+
+    def restore_models_from_database(self):
+        # query database for all jsonb in checksum table
+        json_descriptor_list = self.get_stored_descriptors()
+
+        # if json_descriptor_list is empty can we return?
+
+        # load each item into our models
+        for descriptor in json_descriptor_list:
+            table_name, table_schema, api_schema = self.split_metadata_from_descriptor(descriptor)
+            data_model = self.orm_factory.create_orm_from_dict(
+                table_schema, table_name, api_schema)
+
+        return
 
     def get_sleep_interval(self):
         """Retrieve the thread's sleep interval.
@@ -183,7 +209,7 @@ class DataModelManagerSync(object):
                 break
         return index
 
-    def add_model_checksum(self, table_name: str, model_checksum: str = '0'):
+    def add_model_checksum(self, table_name: str, model_checksum: str = '0', descriptor_json: dict = {}):
         """Adds a new checksum for a data model.
 
         Args:
@@ -195,6 +221,7 @@ class DataModelManagerSync(object):
             checksum = Checksum()
             checksum.data_resource = table_name
             checksum.model_checksum = model_checksum
+            checksum.descriptor_json = descriptor_json
             session.add(checksum)
             session.commit()
         except Exception as e:
@@ -244,6 +271,33 @@ class DataModelManagerSync(object):
             self.logger.exception('Error retrieving checksum')
         session.close()
         return checksum
+
+    def get_stored_descriptors(self):
+        """
+        Gets stored json models from database.
+
+        """
+        session = Session()
+        descriptor_list = []
+        try:
+            query = session.query(Checksum)
+            for _row in query.all():
+                descriptor_list.append(_row.descriptor_json)  # may want to just yield this?
+        except Exception as e:
+            self.logger.exception('Error retrieving stored models')
+        session.close()
+
+        #
+        # move this to its own function that restore_models_from_database is calling
+        # and take the yield from get_stored_models for the in variable
+        #
+        # load each item into a json object and put in a list
+        # json_descriptors_list = []
+        # for descriptor in descriptor_list:
+        #     descriptor_dict = json.load(descriptor)
+        #     json_descriptors_list.append(descriptor_dict)
+
+        return descriptor_list
 
     def get_alembic_config(self):
         """ Load the Alembic configuration.
@@ -302,17 +356,21 @@ class DataModelManagerSync(object):
         self.logger.info('Checking data models')
         schema_dir = self.get_data_resource_schema_path()
 
+        # Do some error checking on the provided path
         if not os.path.exists(schema_dir) or not os.path.isdir(schema_dir):
             self.logger.exception(
                 f"Unable to locate schema directory '{schema_dir}'")
 
+        # iterate over every descriptor file
         schemas = os.listdir(schema_dir)
         for schema in schemas:
+            # ignore folders
             if os.path.isdir(os.path.join(schema_dir, schema)):
                 self.logger.exception(
                     f"Cannot open a nested schema directory '{schema}'")
                 continue
 
+            # Open the file and store its json data and file name
             try:
                 with open(os.path.join(schema_dir, schema), 'r') as fh:
                     schema_dict = json.load(fh)
@@ -322,9 +380,17 @@ class DataModelManagerSync(object):
                 self.logger.exception(
                     f"Error loading json from schema file '{schema}'")
 
+            # Pass the json data and filename to the worker function
             self.work_on_schema(schema_dict, schema_filename)
 
         self.logger.info('Completed check of data models')
+
+    def split_metadata_from_descriptor(self, schema_dict: dict):
+        table_name = schema_dict['datastore']['tablename']
+        table_schema = schema_dict['datastore']['schema']
+        api_schema = schema_dict['api']['methods'][0]
+
+        return table_name, table_schema, api_schema
 
     def work_on_schema(self, schema_dict: dict, schema_filename: str):
         """Operate on a schema dict for data model changes.
@@ -336,11 +402,13 @@ class DataModelManagerSync(object):
             new Alembic migrations to meet these changes. The data models will then have
             to be reconstructed by each individual worker.
         """
-        try:
-            table_name = schema_dict['datastore']['tablename']
-            table_schema = schema_dict['datastore']['schema']
-            api_schema = schema_dict['api']['methods'][0]
+        self.logger.info(f"Looking at {schema_filename}")
 
+        try:
+            # Extract data from the json
+            table_name, table_schema, api_schema = self.split_metadata_from_descriptor(schema_dict)
+
+            # calculate the checksum for this json
             model_checksum = md5(
                 json.dumps(
                     table_schema,
@@ -348,40 +416,72 @@ class DataModelManagerSync(object):
                 ).encode('utf-8')
             ).hexdigest()
 
-            if self.data_model_exists(schema_filename):
-                if not self.data_model_changed(schema_filename, model_checksum):
-                    return
+            self.logger.info('Pre: ' + str(Base.metadata.tables.keys()))
 
+            # Check if data model exists by checking if we have stored metadata about it
+            if self.data_model_exists(schema_filename):
+                self.logger.info(f"{schema_filename}: Found existing.")
+                # check if the cached db checksum has changed from the new file checksum
+                if not self.data_model_changed(schema_filename, model_checksum):
+                    self.logger.info(f"{schema_filename}: Unchanged.")
+                    return
+                
+                self.logger.info(f"{schema_filename}: Found changed.")
+
+                # Get the index for this descriptor within our local metadata
                 data_model_index = self.get_data_model_index(
                     schema_filename)
+                
+                # Create the sql alchemy orm
                 data_model = self.orm_factory.create_orm_from_dict(
                     table_schema, table_name, api_schema)
+                
+                # Something needs to be modified
                 self.revision(table_name, create_table=False)
                 self.upgrade()
                 self.update_model_checksum(
                     table_name, model_checksum)
                 del data_model
+
+                self.logger.info('Post1: ' + Base.metadata.tables.keys())
+
+                # store metadata for descriptor locally
                 self.data_model_descriptors[data_model_index].model_checksum = model_checksum
 
             else:
+                self.logger.info(f"{schema_filename}: Unseen before now.")
+                # Create the metadata store for descriptor
                 data_model_descriptor = DataModelDescriptor(
                     schema_filename, table_name, model_checksum)
+
+                # Store the metadata for descriptor locally
                 self.data_model_descriptors.append(
                     data_model_descriptor)
+                # get the databases checksum value
                 stored_checksum = self.get_model_checksum(
                     table_name)
+
+                # create SqlAlchemy ORM models
                 data_model = self.orm_factory.create_orm_from_dict(
                     table_schema, table_name, api_schema)
+
+                # if there is no checksum in the data base
+                # or the database checksum does not equal this files checksum
                 if stored_checksum is None or stored_checksum.model_checksum != model_checksum:
+                    # perform a revision
                     self.revision(table_name)
                     self.upgrade()
                     self.add_model_checksum(
-                        table_name, model_checksum)
-                del data_model
+                        table_name, model_checksum, schema_dict)
+                del data_model  # this can probably be removed?
+
+                self.logger.info('Post2: ' + str(Base.metadata.tables.keys()))
 
         except Exception as e:
             self.logger.exception(
                 f"Error loading data resource schema '{schema_filename}'")
+
+        self.logger.info('Post3: ' + str(Base.metadata.tables.keys()))
 
 
 class DataModelManager(Thread, DataModelManagerSync):

--- a/data_resource_api/db/checksum.py
+++ b/data_resource_api/db/checksum.py
@@ -5,6 +5,7 @@
 from data_resource_api.db import Base
 from sqlalchemy import Column, String, DateTime
 from sqlalchemy.sql import func
+from sqlalchemy.dialects.postgresql import JSONB
 
 
 class Checksum(Base):
@@ -19,3 +20,4 @@ class Checksum(Base):
     data_resource = Column(String, primary_key=True)
     model_checksum = Column(String, nullable=False)
     date_modified = Column(DateTime, default=func.now())
+    descriptor_json = Column(JSONB)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -14,7 +14,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
https://app.clubhouse.io/brighthive/story/312/prevent-previous-migrations-from-being-undone-when-new-data-resources-are-deployed

https://github.com/brighthive/data-resource-api/issues/50
https://github.com/brighthive/data-resource-api/issues/49

This PR solves a bug that was found on deployment.

The long and short of it is when the Data Model Manager (DMM) is restarted it forgets all of the SQL Alchemy model data it had. It will then proceed to load descriptor files one by one and perform upgrades based on only having one descriptor loaded and seeing that the database has a ton of descriptors. Alembic will then try to drop all of the tables it sees in the database that are not present in the the first descriptor it loads.

The solution to this is on startup DMM will load all of the previous descriptors from the database. That means in this solution everytime the DMM loads a descriptor it is also saving the JSON file to the database.

Upon first manual test this seems to fix the drop table bug.

Steps to reproduce the bug:

1. Put three descriptor files into schema folder
2. Run database, DMM, DRM
3. kill the DMM
4. Add a descriptor file that will be run before the other descriptor files (try naming it a.json)
5. run the DMM

This set of steps will produce a migration that attempts to drop all of the tables that have not yet been loaded.

This solution prevents the bug from occurring.