### PR TITLE
When a descriptor file updates (changes checksum) it cannot be pushed to DB

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ sphinx = "*"
 expects = "*"
 docker = "*"
 flake8 = "*"
+pytest-mock = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d70b735be5f91f8d49890675df0eae3728269ea16014a02ddb57599edaa29bd9"
+            "sha256": "959d8a7a7d2de1a75a301126b365193242b5c0c97e94840aa3574abf76986546"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,17 +45,17 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:50105a25e301e20b361b2b8fafee196a425a4758e51f400a0f381d42e4bd909e",
-                "sha256:5fe70e656f92e4e649dc4cf05786f57d180e5d491bcb22c80411512ec2b27c15"
+                "sha256:5dd06fdc820da2d2efedb365345bc822755ba6e018ce46a2920ecda60ba48d22",
+                "sha256:9549cb07e0f2bd93be90fbf7e544de8e441e448decda8d72defceb1bd8b51686"
             ],
-            "version": "==1.12.21"
+            "version": "==1.12.24"
         },
         "botocore": {
             "hashes": [
-                "sha256:4aaf6c94bcaace260138d32eae144be1b5d2ddce9ef0f395da32c68e106ff20f",
-                "sha256:86f7f1c489887f9e3c2ede598e2a30f8bd259c11e8ebe25e897e40231b3f4bc8"
+                "sha256:85f1c3f402925a1b896ff198b01cb55e34e7bd28f7ce5ff3450bcfe69376bddd",
+                "sha256:d27c2b800be3eb20dac1a539ddee268acdeb07f2abd3f326e2d88b528017e7ad"
             ],
-            "version": "==1.15.21"
+            "version": "==1.15.24"
         },
         "brighthive-authlib": {
             "hashes": [
@@ -713,39 +713,39 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:15cf13a6896048d6d947bf7d222f36e4809ab926894beb748fc9caa14605d9c3",
-                "sha256:1daa3eceed220f9fdb80d5ff950dd95112cd27f70d004c7918ca6dfc6c47054c",
-                "sha256:1e44a022500d944d42f94df76727ba3fc0a5c0b672c358b61067abb88caee7a0",
-                "sha256:25dbf1110d70bab68a74b4b9d74f30e99b177cde3388e07cc7272f2168bd1477",
-                "sha256:3230d1003eec018ad4a472d254991e34241e0bbd513e97a29727c7c2f637bd2a",
-                "sha256:3dbb72eaeea5763676a1a1efd9b427a048c97c39ed92e13336e726117d0b72bf",
-                "sha256:5012d3b8d5a500834783689a5d2292fe06ec75dc86ee1ccdad04b6f5bf231691",
-                "sha256:51bc7710b13a2ae0c726f69756cf7ffd4362f4ac36546e243136187cfcc8aa73",
-                "sha256:527b4f316e6bf7755082a783726da20671a0cc388b786a64417780b90565b987",
-                "sha256:722e4557c8039aad9592c6a4213db75da08c2cd9945320220634f637251c3894",
-                "sha256:76e2057e8ffba5472fd28a3a010431fd9e928885ff480cb278877c6e9943cc2e",
-                "sha256:77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef",
-                "sha256:7afad9835e7a651d3551eab18cbc0fdb888f0a6136169fbef0662d9cdc9987cf",
-                "sha256:9bea19ac2f08672636350f203db89382121c9c2ade85d945953ef3c8cf9d2a68",
-                "sha256:a8b8ac7876bc3598e43e2603f772d2353d9931709345ad6c1149009fd1bc81b8",
-                "sha256:b0840b45187699affd4c6588286d429cd79a99d509fe3de0f209594669bb0954",
-                "sha256:b26aaf69713e5674efbde4d728fb7124e429c9466aeaf5f4a7e9e699b12c9fe2",
-                "sha256:b63dd43f455ba878e5e9f80ba4f748c0a2156dde6e0e6e690310e24d6e8caf40",
-                "sha256:be18f4ae5a9e46edae3f329de2191747966a34a3d93046dbdf897319923923bc",
-                "sha256:c312e57847db2526bc92b9bfa78266bfbaabac3fdcd751df4d062cd4c23e46dc",
-                "sha256:c60097190fe9dc2b329a0eb03393e2e0829156a589bd732e70794c0dd804258e",
-                "sha256:c62a2143e1313944bf4a5ab34fd3b4be15367a02e9478b0ce800cb510e3bbb9d",
-                "sha256:cc1109f54a14d940b8512ee9f1c3975c181bbb200306c6d8b87d93376538782f",
-                "sha256:cd60f507c125ac0ad83f05803063bed27e50fa903b9c2cfee3f8a6867ca600fc",
-                "sha256:d513cc3db248e566e07a0da99c230aca3556d9b09ed02f420664e2da97eac301",
-                "sha256:d649dc0bcace6fcdb446ae02b98798a856593b19b637c1b9af8edadf2b150bea",
-                "sha256:d7008a6796095a79544f4da1ee49418901961c97ca9e9d44904205ff7d6aa8cb",
-                "sha256:da93027835164b8223e8e5af2cf902a4c80ed93cb0909417234f4a9df3bcd9af",
-                "sha256:e69215621707119c6baf99bda014a45b999d37602cb7043d943c76a59b05bf52",
-                "sha256:ea9525e0fef2de9208250d6c5aeeee0138921057cd67fcef90fbed49c4d62d37",
-                "sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0"
+                "sha256:03f630aba2b9b0d69871c2e8d23a69b7fe94a1e2f5f10df5049c0df99db639a0",
+                "sha256:046a1a742e66d065d16fb564a26c2a15867f17695e7f3d358d7b1ad8a61bca30",
+                "sha256:0a907199566269e1cfa304325cc3b45c72ae341fbb3253ddde19fa820ded7a8b",
+                "sha256:165a48268bfb5a77e2d9dbb80de7ea917332a79c7adb747bd005b3a07ff8caf0",
+                "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823",
+                "sha256:1f66cf263ec77af5b8fe14ef14c5e46e2eb4a795ac495ad7c03adc72ae43fafe",
+                "sha256:2e08c32cbede4a29e2a701822291ae2bc9b5220a971bba9d1e7615312efd3037",
+                "sha256:3844c3dab800ca8536f75ae89f3cf566848a3eb2af4d9f7b1103b4f4f7a5dad6",
+                "sha256:408ce64078398b2ee2ec08199ea3fcf382828d2f8a19c5a5ba2946fe5ddc6c31",
+                "sha256:443be7602c790960b9514567917af538cac7807a7c0c0727c4d2bbd4014920fd",
+                "sha256:4482f69e0701139d0f2c44f3c395d1d1d37abd81bfafbf9b6efbe2542679d892",
+                "sha256:4a8a259bf990044351baf69d3b23e575699dd60b18460c71e81dc565f5819ac1",
+                "sha256:513e6526e0082c59a984448f4104c9bf346c2da9961779ede1fc458e8e8a1f78",
+                "sha256:5f587dfd83cb669933186661a351ad6fc7166273bc3e3a1531ec5c783d997aac",
+                "sha256:62061e87071497951155cbccee487980524d7abea647a1b2a6eb6b9647df9006",
+                "sha256:641e329e7f2c01531c45c687efcec8aeca2a78a4ff26d49184dce3d53fc35014",
+                "sha256:65a7e00c00472cd0f59ae09d2fb8a8aaae7f4a0cf54b2b74f3138d9f9ceb9cb2",
+                "sha256:6ad6ca45e9e92c05295f638e78cd42bfaaf8ee07878c9ed73e93190b26c125f7",
+                "sha256:73aa6e86034dad9f00f4bbf5a666a889d17d79db73bc5af04abd6c20a014d9c8",
+                "sha256:7c9762f80a25d8d0e4ab3cb1af5d9dffbddb3ee5d21c43e3474c84bf5ff941f7",
+                "sha256:85596aa5d9aac1bf39fe39d9fa1051b0f00823982a1de5766e35d495b4a36ca9",
+                "sha256:86a0ea78fd851b313b2e712266f663e13b6bc78c2fb260b079e8b67d970474b1",
+                "sha256:8a620767b8209f3446197c0e29ba895d75a1e272a36af0786ec70fe7834e4307",
+                "sha256:922fb9ef2c67c3ab20e22948dcfd783397e4c043a5c5fa5ff5e9df5529074b0a",
+                "sha256:9fad78c13e71546a76c2f8789623eec8e499f8d2d799f4b4547162ce0a4df435",
+                "sha256:a37c6233b28e5bc340054cf6170e7090a4e85069513320275a4dc929144dccf0",
+                "sha256:c3fc325ce4cbf902d05a80daa47b645d07e796a80682c1c5800d6ac5045193e5",
+                "sha256:cda33311cb9fb9323958a69499a667bd728a39a7aa4718d7622597a44c4f1441",
+                "sha256:db1d4e38c9b15be1521722e946ee24f6db95b189d1447fa9ff18dd16ba89f732",
+                "sha256:eda55e6e9ea258f5e4add23bcf33dc53b2c319e70806e180aecbff8d90ea24de",
+                "sha256:f372cdbb240e09ee855735b9d85e7f50730dcfb6296b74b95a3e5dea0615c4c1"
             ],
-            "version": "==5.0.3"
+            "version": "==5.0.4"
         },
         "docker": {
             "hashes": [
@@ -930,6 +930,14 @@
             ],
             "index": "pypi",
             "version": "==2.8.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:b35eb281e93aafed138db25c8772b95d3756108b601947f89af503f8c629413f",
+                "sha256:cb67402d87d5f53c579263d37971a164743dc33c159dfb4fb4a86f37c5552307"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "pytz": {
             "hashes": [

--- a/data_resource_api/app/data_managers/data_manager.py
+++ b/data_resource_api/app/data_managers/data_manager.py
@@ -99,10 +99,9 @@ class DataManager(object):
             name_attr: str,
             checksum_attr: str):
         for data_object in self.data_store:
-            same_name = getattr(
-                data_object, name_attr).lower == data_name.lower
-            same_checksum = getattr(data_object, checksum_attr) != checksum
-            if same_name and same_checksum:
+            same_name = getattr(data_object, name_attr).lower() == data_name.lower()
+            same_checksum = getattr(data_object, checksum_attr) == checksum
+            if same_name and not same_checksum:
                 return True
         return False
 

--- a/data_resource_api/app/data_managers/data_model_manager.py
+++ b/data_resource_api/app/data_managers/data_model_manager.py
@@ -142,9 +142,6 @@ class DataModelManagerSync(DataManager):
     def data_model_does_exist(self, descriptor: Descriptor):
         try:
             descriptor_file_name = descriptor.file_name
-            table_name = descriptor.table_name
-            table_schema = descriptor.table_schema
-            api_schema = descriptor.api_schema
             model_checksum = descriptor.get_checksum()
 
             self.logger.debug(f"{descriptor_file_name}: Found existing.")
@@ -154,6 +151,19 @@ class DataModelManagerSync(DataManager):
                     descriptor_file_name, model_checksum):
                 self.logger.debug(f"{descriptor_file_name}: Unchanged.")
                 return
+
+            self.update_data_model(descriptor)
+        except Exception:
+            self.logger.exception(
+                'Error checking data model')
+
+    def update_data_model(self, descriptor: Descriptor):
+        try:
+            descriptor_file_name = descriptor.file_name
+            table_name = descriptor.table_name
+            table_schema = descriptor.table_schema
+            api_schema = descriptor.api_schema
+            model_checksum = descriptor.get_checksum()
 
             self.logger.debug(f"{descriptor_file_name}: Found changed.")
 
@@ -169,7 +179,7 @@ class DataModelManagerSync(DataManager):
             self.db.revision(table_name, create_table=False)
             self.db.upgrade()
             self.db.update_model_checksum(
-                table_name, model_checksum)
+                table_name, model_checksum, descriptor.descriptor)
 
             # store metadata for descriptor locally
             self.data_store[data_model_index].model_checksum = model_checksum

--- a/data_resource_api/app/data_managers/data_model_manager.py
+++ b/data_resource_api/app/data_managers/data_model_manager.py
@@ -125,15 +125,10 @@ class DataModelManagerSync(DataManager):
             self.logger.info(
                 f"Loading descriptor '{remote_descriptor.table_name}' from db.")
 
-            self.load_descriptor_into_sql_alchemy_model(
+            self.load_model_to_data_store(
                 remote_descriptor)
 
         self.logger.info("Loaded remote descriptors.")
-
-    def load_descriptor_into_sql_alchemy_model(
-            self, desc: Descriptor) -> None:
-        _ = self.orm_factory.create_orm_from_dict(
-            desc.table_schema, desc.table_name, desc.api_schema)
 
     def process_descriptor(self, descriptor: Descriptor):
         model_exists = self.data_model_exists(descriptor.file_name)
@@ -143,13 +138,14 @@ class DataModelManagerSync(DataManager):
         try:
             descriptor_file_name = descriptor.file_name
             model_checksum = descriptor.get_checksum()
+            self.logger.info(f"{descriptor_file_name}: {model_checksum}")
 
-            self.logger.debug(f"{descriptor_file_name}: Found existing.")
+            self.logger.info(f"{descriptor_file_name}: Found existing.")
             # check if the cached db checksum has changed from the new file
             # checksum
             if not self.data_model_changed(
                     descriptor_file_name, model_checksum):
-                self.logger.debug(f"{descriptor_file_name}: Unchanged.")
+                self.logger.info(f"{descriptor_file_name}: Unchanged.")
                 return
 
             self.update_data_model(descriptor)
@@ -165,7 +161,7 @@ class DataModelManagerSync(DataManager):
             api_schema = descriptor.api_schema
             model_checksum = descriptor.get_checksum()
 
-            self.logger.debug(f"{descriptor_file_name}: Found changed.")
+            self.logger.info(f"{descriptor_file_name}: Found changed.")
 
             # Get the index for this descriptor within our local metadata
             data_model_index = self.get_data_model_index(
@@ -191,26 +187,16 @@ class DataModelManagerSync(DataManager):
         try:
             descriptor_file_name = descriptor.file_name
             table_name = descriptor.table_name
-            table_schema = descriptor.table_schema
-            api_schema = descriptor.api_schema
             model_checksum = descriptor.get_checksum()
 
-            self.logger.debug(
+            self.logger.info(
                 f"{descriptor_file_name}: Unseen before now.")
-            # Create the metadata store for descriptor
-            data_model_descriptor = DataModelDescriptor(
-                descriptor_file_name, table_name, model_checksum)
 
-            # Store the metadata for descriptor locally
-            self.data_store.append(
-                data_model_descriptor)
+            self.load_model_to_data_store(descriptor)
+
             # get the databases checksum value
             stored_checksum = self.db.get_model_checksum(
                 table_name)
-
-            # create SqlAlchemy ORM models
-            _ = self.orm_factory.create_orm_from_dict(
-                table_schema, table_name, api_schema)
 
             # if there is no checksum in the data base
             # or the database checksum does not equal this files checksum
@@ -225,6 +211,21 @@ class DataModelManagerSync(DataManager):
                 'Error checking data resource')
 
     # Data store functions
+    def load_model_to_data_store(self, descriptor):
+        """Adds descriptor to data store AND loads SQL Alchemy model
+        """
+        # Create the metadata store for descriptor
+        data_model_descriptor = DataModelDescriptor(
+            descriptor.file_name, descriptor.table_name, descriptor.get_checksum())
+
+        # Store the metadata for descriptor locally
+        self.data_store.append(
+            data_model_descriptor)
+
+        # create SqlAlchemy ORM models
+        _ = self.orm_factory.create_orm_from_dict(
+            descriptor.table_schema, descriptor.table_name, descriptor.api_schema)
+
     def data_model_exists(self, descriptor_file_name):
         """Checks if a data model is already registered with the data model manager.
 

--- a/data_resource_api/app/utils/db_handler.py
+++ b/data_resource_api/app/utils/db_handler.py
@@ -34,7 +34,7 @@ class DBHandler(object):
         finally:
             session.close()
 
-    def update_model_checksum(self, table_name: str, model_checksum: str):
+    def update_model_checksum(self, table_name: str, model_checksum: str, descriptor_json: dict = {}):
         """Updates a checksum for a data model.
 
         Args:
@@ -51,6 +51,7 @@ class DBHandler(object):
             checksum = session.query(Checksum).filter(
                 Checksum.data_resource == table_name).first()
             checksum.model_checksum = model_checksum
+            checksum.descriptor_json = descriptor_json
             session.commit()
             updated = True
         except Exception:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - POSTGRES_PORT=5432
     command: "--data-model-manager"
     volumes:
-      - ./migrations:/data-resource/migrations:rw
       - ./schema:/data-resource/schema
   data-resource-api:
     image: brighthive/data-resource-api:1.1.0-alpha

--- a/scripts/run_dmm.sh
+++ b/scripts/run_dmm.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t brighthive/data-resource-api:1.1.0-alpha . && docker system prune -f && docker-compose up data-model-manager

--- a/scripts/run_drm_db.sh
+++ b/scripts/run_drm_db.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t brighthive/data-resource-api:1.1.0-alpha . && docker system prune -f && docker-compose up data-resource-api postgres

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,7 +213,6 @@ def no_db_dmm():
     dmm = DataModelManagerSync(
         use_local_dirs=False,
         descriptors=None)
-    print("test fixture")
     yield dmm
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,15 @@ def json_client():
     client.stop_container()
 
 
+@pytest.fixture(scope='module')
+def no_db_dmm():
+    dmm = DataModelManagerSync(
+        use_local_dirs=False,
+        descriptors=None)
+    print("test fixture")
+    yield dmm
+
+
 @pytest.fixture
 def base():
     JuncHolder.reset()

--- a/tests/data_model_manager/test_dmm.py
+++ b/tests/data_model_manager/test_dmm.py
@@ -37,17 +37,6 @@ def test_add_checksum(no_db_dmm, mocker):
     fn_update_model_checksum.assert_called()
 
 
-def test_add_checksum(no_db_dmm, mocker):
-    mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.revision', return_value=True)
-    mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.upgrade', return_value=True)
-    fn_update_model_checksum = mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.update_model_checksum', return_value=True)
-    desc = Descriptor(frameworks_descriptor)
-
-    no_db_dmm.update_data_model(desc)
-
-    fn_update_model_checksum.assert_called()
-
-
 class TestDataModelManager():
     @pytest.mark.xfail  # this is failing because of a strange interaction with juncholder
     # this test will pass if run by itself -- if run with all other tests it

--- a/tests/data_model_manager/test_dmm.py
+++ b/tests/data_model_manager/test_dmm.py
@@ -8,6 +8,7 @@ from tests.schemas import (
     credentials_descriptor,
     programs_descriptor)
 import pytest
+from data_resource_api.app.utils.descriptor import Descriptor
 
 
 def setup_dmm_store():
@@ -23,6 +24,28 @@ def setup_dmm_store():
     DMM.data_store.append(d3)
 
     return DMM
+
+
+def test_add_checksum(no_db_dmm, mocker):
+    mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.revision', return_value=True)
+    mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.upgrade', return_value=True)
+    fn_update_model_checksum = mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.add_model_checksum', return_value=True)
+    desc = Descriptor(frameworks_descriptor)
+
+    no_db_dmm.update_data_model(desc)
+
+    fn_update_model_checksum.assert_called()
+
+
+def test_add_checksum(no_db_dmm, mocker):
+    mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.revision', return_value=True)
+    mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.upgrade', return_value=True)
+    fn_update_model_checksum = mocker.patch('data_resource_api.app.utils.db_handler.DBHandler.update_model_checksum', return_value=True)
+    desc = Descriptor(frameworks_descriptor)
+
+    no_db_dmm.update_data_model(desc)
+
+    fn_update_model_checksum.assert_called()
 
 
 class TestDataModelManager():


### PR DESCRIPTION
This PR fixes a bug that was introduced. Data Managers will correctly search their data stores for changes.

On descriptor update this will also update the descriptor JSON in the database.





Story details: https://app.clubhouse.io/brighthive/story/651