### PR TITLE
SQLAlchemy, clear database content but don't drop the schema

### DIFF
--- a/scripts/run_tests_with_db_up.sh
+++ b/scripts/run_tests_with_db_up.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+DR_LEAVE_DB=true pipenv run pytest


### PR DESCRIPTION
Story details: https://app.clubhouse.io/brighthive/story/681

This PR makes two significant improvements to the test suite.

1. Database will stay up during the duration of the test. Between module tests the entire DB is emptied.
2. Each function level test will perform a tear down and clear the database and will preserve the tables present.


In total this reduces the full test time from one minute to 3 seconds.

If the database needs to be stood or taken down it takes 7 seconds to perform on my machine. If you want to leave the database up after the tests have been run for the lightning fast 3 second tests then provide the following env var:
```bash
DR_LEAVE_DB=true pipenv run pytest
```